### PR TITLE
Support for python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 python:
     - 2.7
+    - 3.4
 services:
     - redis-server
 env:
-    - DJANGO_VERSION=1.7.7
+    - DJANGO_VERSION=1.7.10
+    - DJANGO_VERSION=1.8.4
 install:
     # Install requirements
     - pip install -r requirements.txt

--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -29,7 +29,7 @@ class AutocompleterBase(object):
 
     @classmethod
     def _deserialize_data(cls, raw):
-        return json.loads(raw)
+        return json.loads(raw.decode('utf-8'))
 
 
 class AutocompleterProviderBase(AutocompleterBase):
@@ -575,14 +575,14 @@ class Autocompleter(AutocompleterBase):
                 # get a list of providers with deficits for two reasons. First, to know how
                 # to divide the surplus, secondly, to iterate over rather than the deficit dict
                 # as we will be manipulating the dict in the for loop
-                beneficiaries = deficits.keys()
+                beneficiaries = list(deficits.keys())
                 num_beneficiaries = len(beneficiaries)
                 # if num_beneficiaries is greater than surplus, surplus_each will be 0 because of int
                 # division in python, but total_surplus will still be > 0, resulting in infinite loop.
                 if num_beneficiaries == 0 or num_beneficiaries > total_surplus:
                     break
                 else:
-                    surplus_payout = total_surplus / num_beneficiaries
+                    surplus_payout = int(total_surplus / num_beneficiaries)
                     for provider in beneficiaries:
                         deficit = deficits.pop(provider)
                         if (deficit - surplus_payout) <= 0:
@@ -677,8 +677,8 @@ class Autocompleter(AutocompleterBase):
                 provider_results[provider_name] = \
                     [self.__class__._deserialize_data(i) for i in results.pop(0) if i is not None]
 
-        if settings.FLATTEN_SINGLE_TYPE_RESULTS and len(provider_results.keys()) == 1:
-            provider_results = provider_results.values()[0]
+        if settings.FLATTEN_SINGLE_TYPE_RESULTS and len(provider_results) == 1:
+            provider_results = list(provider_results.values())[0]
         return provider_results
 
     def _get_all_providers_by_autocompleter(self):

--- a/autocompleter/utils.py
+++ b/autocompleter/utils.py
@@ -2,6 +2,7 @@ import copy
 import re
 import unicodedata
 import itertools
+import six
 
 from autocompleter import settings
 
@@ -26,10 +27,10 @@ def get_normalized_term(term, replaced_chars=[]):
     7) Remove extra spaces
     8) Remove all characters that are not alphanumeric
     """
-    if type(term) == str:
+    if isinstance(term, six.binary_type):
         term = term.decode('utf-8')
     term = term.lower()
-    term = unicodedata.normalize('NFKD', unicode(term)).encode('ASCII', 'ignore')
+    term = unicodedata.normalize('NFKD', term).encode('ASCII', 'ignore').decode('utf-8')
     term = term.replace('&', 'and')
     term = term.strip()
     if replaced_chars != []:
@@ -118,7 +119,7 @@ def get_aliased_variations(term, phrase_aliases):
                     term_alias_phrase_ranges.append((aliasable_phrase_start, aliasable_phrase_end,))
                     term_aliases[term_alias] = term_alias_phrase_ranges
 
-    return term_aliases.keys()
+    return list(term_aliases.keys())
 
 # Here we build the dict where 1 phrase can map to 1 or more aliased phrases
 def build_norm_phrase_alias_dict(phrase_alias_dict, two_way=True):

--- a/autocompleter/utils.py
+++ b/autocompleter/utils.py
@@ -2,7 +2,6 @@ import copy
 import re
 import unicodedata
 import itertools
-import six
 
 from autocompleter import settings
 
@@ -27,7 +26,7 @@ def get_normalized_term(term, replaced_chars=[]):
     7) Remove extra spaces
     8) Remove all characters that are not alphanumeric
     """
-    if isinstance(term, six.binary_type):
+    if isinstance(term, bytes):
         term = term.decode('utf-8')
     term = term.lower()
     term = unicodedata.normalize('NFKD', term).encode('ASCII', 'ignore').decode('utf-8')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 Django>=1.7
 hiredis
 redis>=2.4.10
-six==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 Django>=1.7
 hiredis
 redis>=2.4.10
+six==1.9.0

--- a/test_project/test_app/tests/base.py
+++ b/test_project/test_app/tests/base.py
@@ -1,11 +1,11 @@
-from django_nose import FastFixtureTestCase
 import redis
 
 from django.conf import settings
 from django.core import management
+from django.test import TestCase
 
 
-class AutocompleterTestCase(FastFixtureTestCase):
+class AutocompleterTestCase(TestCase):
     def setUp(self):
         self.redis = redis.Redis(host=settings.AUTOCOMPLETER_REDIS_CONNECTION['host'],
             port=settings.AUTOCOMPLETER_REDIS_CONNECTION['port'],


### PR DESCRIPTION
Handle some unicode quirks. Redis returns everything as bytes so we need
to decode to unicode.

Django nose's FastFixtureTestCase hasn't been updated to work with
Django > 1.6 and also doesn't work with python 3 so that was switched
out for Django's TestCase.