### PR TITLE
No longer allow non-inclusive items to stay in autocompleter.

### DIFF
--- a/autocompleter/base.py
+++ b/autocompleter/base.py
@@ -263,8 +263,6 @@ class AutocompleterProviderBase(AutocompleterBase):
         DO NOT override this.
         """
         # Init data
-        if not self.include_item():
-            return
         provider_name = self.get_provider_name()
         obj_id = self.get_item_id()
         terms = self.get_terms()
@@ -447,7 +445,10 @@ class Autocompleter(AutocompleterBase):
 
         for provider_class in provider_classes:
             for obj in provider_class.get_iterator():
-                provider_class(obj).store(delete_old=delete_old)
+                provider = provider_class(obj)
+                if provider.include_item():
+                    provider.store(delete_old=delete_old)
+
 
     def remove_all(self):
         """

--- a/autocompleter/management/commands/autocompleter_init.py
+++ b/autocompleter/management/commands/autocompleter_init.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
     help = "Store and/or remove autocompleter data"
 
     def handle(self, *args, **options):
-        # Configure loggingin
+        # Configure logging
         level = {
             0: logging.WARN,
             1: logging.INFO,

--- a/autocompleter/registry.py
+++ b/autocompleter/registry.py
@@ -174,18 +174,25 @@ def add_obj_to_autocompleter(sender, instance, created, **kwargs):
     if instance is None:
         return
 
-    providers = registry.get_all_by_model(sender)
-    for provider in providers:
-        provider(instance).store()
+    provider_classes = registry.get_all_by_model(sender)
+    for provider_class in provider_classes:
+        provider = provider_class(instance)
+        # TODO: Consider that this will now be called twice...
+        if provider.include_item():
+            provider.store()
+        else:
+            # If the item no longer passes the .include_item()
+            # check then we need to remove it.
+            provider.remove()
 
 
 def remove_obj_from_autocompleter(sender, instance, **kwargs):
     if instance is None:
         return
 
-    providers = registry.get_all_by_model(sender)
-    for provider in providers:
-        provider(instance).remove()
+    provider_classes = registry.get_all_by_model(sender)
+    for provider_class in provider_classes:
+        provider_class(instance).remove()
 
 
 class AutocompleterSignalRegistry(object):

--- a/test_project/test_app/autocompleters.py
+++ b/test_project/test_app/autocompleters.py
@@ -46,6 +46,12 @@ class FacetedStockAutocompleteProvider(AutocompleterModelProvider):
         """
         return self.obj.market_cap
 
+    def include_item(self):
+        if self.obj.hidden:
+            return False
+        return True
+
+
     @classmethod
     def get_facets(cls):
         return ['sector', 'industry']

--- a/test_project/test_app/models.py
+++ b/test_project/test_app/models.py
@@ -7,6 +7,7 @@ class Stock(models.Model):
     market_cap = models.FloatField(null=True, blank=True)
     sector = models.CharField(max_length=200, default='')
     industry = models.CharField(max_length=200, default='')
+    hidden = models.BooleanField(default=False)
 
 
 class Indicator(models.Model):


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/171366263)

### Overview

Right now the only way items get ejected from the search is by being deleted. We need to update the core autocompleter code to have it be able to eject an item by considering it's post save include_item status and if it no longer passes the test then we eject.



### How to test
- [ ] Unit tests pass

